### PR TITLE
SQL table conversion warning and Ubuntu 20 `libffi.so.6`

### DIFF
--- a/docs/facts/faq.rst
+++ b/docs/facts/faq.rst
@@ -40,13 +40,13 @@ things while running PyFunceble as all of your CPU threads is used by PyFunceble
 
     ::
 
-        $ lscpu | grep -E '^Thread|^Core|^Socket|^CPU\('
+        $: lscpu | grep -E '^Thread|^Core|^Socket|^CPU\('
 
     or
 
     ::
 
-	$ ``$(nproc --ignore=1)``
+	$: nproc --ignore=1
 
 	This will count the number of CPU threads subtracted 1 to use for DB,
 	SQL. If you runs PyFunceble on your workstation you might subtract 2
@@ -55,7 +55,7 @@ things while running PyFunceble as all of your CPU threads is used by PyFunceble
 	See also ``man nproc`` or ``nproc --help``
 
 .. warning::
-    DO NOT try to exceed your total number of CPU cores (as :code:`-p | --processes`),
+    DO NOT try to exceed your total number of CPU cores with (:code:`-p | --processes`),
     if you want to keep your machine somehow alive and healthy.
 
 I do not have multiple CPU

--- a/docs/facts/known_issues.rst
+++ b/docs/facts/known_issues.rst
@@ -5,3 +5,28 @@ This is the list of issues which are not or will not be fixed (yet...).
 
 * Under Travis CI the coloration may not be shown.
 * Under GitLab CI/CD the coloration may not be shown.
+
+
+Ubuntu 20.04.1 LTS Focal
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+In Ubunto release 20.04 they have removed a package name
+:code:`libffi.so.6` and upgraded it with version :code:`libffi.so.7`
+
+This means PyFunceble will trow an error like:
+
+:code:`ImportError: libffi.so.6: cannot open shared object file: No such file or directory`
+
+The fix for this issue is then rather simple, add a softlink between the
+versions with :code:`ln -s`
+
+The complete line in my case was:
+
+:code:`sudo ln -s /usr/lib/x86_64-linux-gnu/libffi.so.7 /usr/lib/x86_64-linux-gnu/libffi.so.6`
+
+However, the right way to do this is by first locate where your's
+:code:`libffi.so.7` is by
+
+:code:`find /usr/lib/ -type f -iname 'libffi.so.*'` and then apply the
+softlink to :code:`libffi.so.7`

--- a/docs/update/dev.rst
+++ b/docs/update/dev.rst
@@ -1,6 +1,32 @@
 Development version
 -------------------
 
+IMPORTANT INFORMATION for :code:`dev >= 3.2.11`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+::
+
+   When you update from dev@3.2.10 or master@3.2.??
+   to newer release, there will be made a SQL
+   conversion of the databases table layout.
+   This can take up a sagnificent amount of time
+   based on the size of the Database.
+   
+   The table layout converion is being made to:
+   
+   1. Minimize the total size
+   
+   2. Optimize the sql flow and minimizing the
+      read/write to save disk I/O
+   
+   3. Minimize the number of SQL queries being made
+   
+   It have been seen taking days to convert these
+   tables on very large installations.
+
+
 For development
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Have added some text about the missing `libffi.so.6` in Ubuntu 20.04.1 LTS Focal
+
Minor wordplay's to make a better reading flow in the faq

The Error message for this is:
```shell
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python3.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-mocpocp3/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-mocpocp3/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-8tqqlmyp                                                                                                                                                                       
         cwd: /tmp/pip-req-build-mocpocp3/                                                                                                                                                     
    Complete output (11 lines):                                                                                                                                                                
    Traceback (most recent call last):                                                                                                                                                         
      File "<string>", line 1, in <module>                                                                                                                                                     
      File "/usr/local/lib/python3.7/site-packages/setuptools/__init__.py", line 19, in <module>                                                                                               
        from setuptools.dist import Distribution                                                                                                                                               
      File "/usr/local/lib/python3.7/site-packages/setuptools/dist.py", line 34, in <module>                                                                                                   
        from setuptools import windows_support                                                                                                                                                 
      File "/usr/local/lib/python3.7/site-packages/setuptools/windows_support.py", line 2, in <module>                                                                                         
        import ctypes                                                                                                                                                                          
      File "/usr/local/lib/python3.7/ctypes/__init__.py", line 7, in <module>                                                                                                                  
        from _ctypes import Union, Structure, Array                                                                                                                                            
    ImportError: libffi.so.6: cannot open shared object file: No such file or directory                                                                                                        
    ----------------------------------------                                                                                                                                                   
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Added a fair warning to the doc about the SQL Table conversion
  - As my SQL is still updating after 24 hours I thought it would be fair to make a note, that this can take up some time...


<details><summary>Own ref:</summary>

T1251

</details>