### PR TITLE
Swicthed the Chromium with palemoon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Simply run the following and enjoy the documentation!
 
     $ cd docs/
     $ make html
-    $ chromium _build/html/index.html # Chromium or whatever browser you use.
+    $ palemoon _build/html/index.html # palemoon or whatever browser you use.
 
 ___________________________________________
 

--- a/docs/configuration/core.rst
+++ b/docs/configuration/core.rst
@@ -536,7 +536,12 @@
     **Description:** Enable / disable the storage of the WHOIS record into the WHOIS DB.
 
 .. warning::
-    This does not disable the WHOIS DB. It just block the storage of the full record.
+    This does not disable the WHOIS DB functionality. It just not storing the full
+    :code:`WHOIS` reply in the database.
+
+.. note: See also `storing-whois <usage/index.html#store-whois>`_ for more information
+
+
 
 :code:`syntax`
 ^^^^^^^^^^^^^^

--- a/docs/usage/from-a-terminal.rst
+++ b/docs/usage/from-a-terminal.rst
@@ -609,9 +609,10 @@ This argument is suited to you!
 
     **Default value:** :code:`False`
 
-This argument is suited to you!
+The difference between :code:`False` or :code:`True` is whether
+we are saving a full dump of the `WHOIS` reply into the database.
 
-If you for some reason believes you need to fill up your databse
+If you for some reason believes you need to fill up your database
 with a complete dump of the whois reply, this is the right value
 to switch on.
 
@@ -619,11 +620,9 @@ to switch on.
     Before switching this value, you should read these comments
     carefully...
     
-    This will copy a full text dump of the whois reply.
-    
     You can test the amount of data by running :code:`whois mypdns.org`
-    from your Linux terminal, to see what will be stored inside the
-    database
+    from your Linux terminal, to see an example of what will be stored
+    in the database.
     
     You're hearby warned...
     

--- a/docs/usage/from-a-terminal.rst
+++ b/docs/usage/from-a-terminal.rst
@@ -609,8 +609,27 @@ This argument is suited to you!
 
     **Default value:** :code:`False`
 
-Want to get the full WHOIS record in your database?
 This argument is suited to you!
+
+If you for some reason believes you need to fill up your databse
+with a complete dump of the whois reply, this is the right value
+to switch on.
+
+.. warning::
+    Before switching this value, you should read these comments
+    carefully...
+    
+    This will copy a full text dump of the whois reply.
+    
+    You can test the amount of data by running :code:`whois mypdns.org`
+    from your Linux terminal, to see what will be stored inside the
+    database
+    
+    You're hearby warned...
+    
+    `store_whois_record comment <https://github.com/funilrys/PyFunceble/issues/57#issuecomment-682597793>`_
+    
+    `Brainstorm whois data comment <https://github.com/funilrys/PyFunceble/issues/108#issuecomment-682522516>`_
 
 Multiprocessing
 ^^^^^^^^^^^^^^^

--- a/docs/usage/from-travis-ci.rst
+++ b/docs/usage/from-travis-ci.rst
@@ -36,7 +36,7 @@ Configuration
     # This is the python version we are going to use for the tests.
     # Note: you can add any 3.x version to the list.
     python:
-    - "3.6"
+    - "3.8"
 
     # The following will tell Travis CI to ends as fast as possible.
     matrix:


### PR DESCRIPTION
This set the palemoon <https://www.palemoon.org/> as the de-facto best privacy browser I've been able to currently find.

Left this as draft for fixing up the `--store-whois` docs at the same time which would be fixing <https://github.com/funilrys/PyFunceble/issues/108>