### PR TITLE
Better versioning for implamentation of sqlalchemy

### DIFF
--- a/docs/update/dev.rst
+++ b/docs/update/dev.rst
@@ -8,7 +8,7 @@ IMPORTANT INFORMATION for :code:`dev >= 3.2.11`
 
 ::
 
-   When you update from dev@3.2.10 or master@3.2.??
+   When you update from dev@<=3.2.10 or master@<=3.2.2
    to newer release, there will be made a SQL
    conversion of the databases table layout.
    This can take up a sagnificent amount of time

--- a/docs/update/stable.rst
+++ b/docs/update/stable.rst
@@ -4,6 +4,31 @@ Stable version
 Using :code:`pip`
 ^^^^^^^^^^^^^^^^^
 
+IMPORTANT INFORMATION for :code:`master >= 3.2.2`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+::
+
+   When you update from version before 3.3.0
+   to newer release, there will be made a SQL
+   conversion of the databases table layout.
+   This can take up a sagnificent amount of time
+   based on the size of the Database.
+   
+   The table layout converion is being made to:
+   
+   1. Minimize the total size
+   
+   2. Optimize the sql flow and minimizing the
+      read/write to save disk I/O
+   
+   3. Minimize the number of SQL queries being made
+   
+   It have been seen taking days to convert these
+   tables on very large installations.
+
 From PyPi
 """""""""
 

--- a/docs/update/stable.rst
+++ b/docs/update/stable.rst
@@ -4,7 +4,7 @@ Stable version
 Using :code:`pip`
 ^^^^^^^^^^^^^^^^^
 
-IMPORTANT INFORMATION for :code:`master >= 3.2.2`
+IMPORTANT INFORMATION for :code:`master >= 3.3.0`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::


### PR DESCRIPTION
Giving it a try to enhange the readability and understanding of `ANY`version prior to version `3.2.11-dev` and `3.3.0`(master)