### PR TITLE
Bumped default versions in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,8 +26,8 @@ If applicable, add screenshots to help explain your problem.
 ## Versions
 
 **OS:** for example Arch Linux (5.0.5-arch1-1-ARCH)
-**Python Version:** for example 3.6.5
-**PyFunceble Version:** for example 1.2.0
+**Python Version:** for example 3.8.5
+**PyFunceble Version:** for example 3.3.0
 
 ## Additional context
 Add any other context about the problem here.


### PR DESCRIPTION
As this template was getting a bit old I have changed the default values for:

 - Python Version:
 - PyFunceble Version: