### PR TITLE
Forcing latest version to pipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic
 colorama
 cryptography
 dnspython[DOH]>=2.0.0
-domain2idna
+domain2idna>=1.12.0
 inflection
 PyMySQL
 python-box[all]>=5.0.0


### PR DESCRIPTION
By forcing the latest version of domain2idna we should be able to solve https://github.com/funilrys/PyFunceble/issues/134#issuecomment-751292658

Fixes https://github.com/funilrys/PyFunceble/issues/157

Contributer:
  - @DandelionSprout