### PR TITLE
Adding Pygments>=2.0

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,3 +1,4 @@
 alabaster<0.8,>=0.7
 sphinx
 sphinx_rtd_theme
+Pygments>=2.0


### PR DESCRIPTION
```python
sphinx 3.4.1 requires packaging, which is not installed.
sphinx 3.4.1 requires Pygments>=2.0, which is not installed.
```

![image](https://user-images.githubusercontent.com/44526987/104062019-f12e9300-51f9-11eb-8200-f23e55b931c5.png)
