### PR TITLE
DOC: Convertion from 3.x to 4.x

### DIFF
--- a/docs/update/dev.rst
+++ b/docs/update/dev.rst
@@ -91,14 +91,6 @@ The image description can be found at https://hub.docker.com/r/pyfunceble/pyfunc
 
    docker pull pyfunceble/pyfunceble-dev
 
-Using :code:`conda`
-"""""""""""""""""""
-
-Our repository is located at https://anaconda.org/pyfunceble/pyfunceble-dev
-
-.. code-block:: bash
-
-   conda update -c conda-forge -c pyfunceble pyfunceble-dev
 
 Pure Python method
 """"""""""""""""""

--- a/docs/update/dev.rst
+++ b/docs/update/dev.rst
@@ -1,55 +1,18 @@
 Development version
 -------------------
 
-Important information for :code:`dev >= 3.2.11`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When you update from dev@<=3.2.10 or master@<=3.2.2 to newer release, there
-will be made a SQL conversion of the databases table layout.
-This can take up a sagnificent amount of time based on the size of the
-database.
-
-The table layout converion is being made to:
-
-1. Minimize the total size
-
-2. Optimize the sql flow and minimizing the read/write to save disk I/O.
-
-3. Minimize the number of SQL queries being made
-
-It have been seen taking days to convert these tables on very large
-installations.
-
-
-Important information for :code:`dev >= 4.0.0`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When you update to PyFunceble :code:`4.0.0`, there will be
-
-- a SQL conversion if you use the :code:`mysql` or `mariadb` database type.
-- a JSON to CSV conversion if one of those files is found in your filesystem:
-
-   - :code:`inactive_db.json`
-   - :code:`whois_db.json`
-
-- a breaking and compatibility issue if you try to directly (automatically ?)
-  read the data in the output directory. Indeed if you were looking for
-  :code:`output/domains/ACTIVE/list` in PyFunceble :code:`3.x`, in :code:`4.0`,
-  it is now under :code:`output/{{ input_file_name }}/domains/ACTIVE list`.
-
-
 For development
 ^^^^^^^^^^^^^^^
 
-::
+.. code-block:: bash
 
-   $ cd PyFunceble && git checkout dev
-   $ git fetch origin && git merge origin/dev
+   cd PyFunceble && git checkout dev
+   git fetch origin && git merge origin/dev
 
 .. note::
    As you previously installed with
 
-   ::
+   .. code-block:: 
 
       $ . venv/bin/activate && pip3 install -e .
 
@@ -64,9 +27,9 @@ Using :code:`pip`
 From PyPi
 ~~~~~~~~~
 
-::
+.. code-block:: bash
 
-   $ pip3 install --user --upgrade PyFunceble-dev
+   pip3 install --user --upgrade PyFunceble-dev
 
 .. note::
    We recommend the :code:`--user` flag which installs the required dependencies
@@ -77,17 +40,19 @@ From PyPi
    We do not recommend the :code:`--user` flag when using :code:`PyFunceble`
    into containers like - for example - Travis CI.
 
+
 From GitHub
 ~~~~~~~~~~~
 
-::
+.. code-block:: bash
 
-   $ pip3 install --user --upgrade git+https://github.com/funilrys/PyFunceble.git@dev#egg=PyFunceble
+   pip3 install --user --upgrade git+https://github.com/funilrys/PyFunceble.git@dev#egg=PyFunceble
 
 .. note::
    We recommend the :code:`--user` flag which installs the required dependencies
    at the user level. More information about it can be found on
    `pip documentation`_.
+
 .. warning::
    We do not recommend the :code:`--user` flag when using :code:`PyFunceble`
    into containers like - for example - Travis CI.
@@ -98,40 +63,40 @@ Using the AUR (for Arch Linux users)
 With makepkg
 ~~~~~~~~~~~~
 
-::
+.. code-block:: bash
 
-    $ wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=python-pyfunceble-dev
-    $ makepkg
-    $ sudo pacman -U python-pyfunceble-dev*.tar.xz
+   wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=python-pyfunceble-dev
+   makepkg
+   sudo pacman -U python-pyfunceble-dev*.tar.xz
 
 With your favorite AUR helper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
-    We do not recommend any AUR helper but keep in mind that some AUR helpers
-    are "better" than other.
-    For more information about your current (or any other) AUR helper please
-    report to `the ArchWiki page`_.
+   We do not recommend any AUR helper but keep in mind that some AUR helpers
+   are "better" than other.
+   For more information about your current (or any other) AUR helper please
+   report to `the ArchWiki page`_.
 
-::
+.. code-block:: bash
 
-    $ yourFavoriteAurHelper -Syu python-pyfunceble-dev
+   yourFavoriteAurHelper -Syu python-pyfunceble-dev
 
 Using docker (hub)
 """"""""""""""""""
 
 The image description can be found at https://hub.docker.com/r/pyfunceble/pyfunceble-dev
 
-::
+.. code-block:: bash
 
-   $ docker pull pyfunceble/pyfunceble-dev
+   docker pull pyfunceble/pyfunceble-dev
 
 Using :code:`conda`
 """""""""""""""""""
 
 Our repository is located at https://anaconda.org/pyfunceble/pyfunceble-dev
 
-::
+.. code-block:: bash
 
    conda update -c conda-forge -c pyfunceble pyfunceble-dev
 
@@ -140,17 +105,18 @@ Pure Python method
 
 Execute the following and enjoy PyFunceble!
 
-::
+.. code-block:: bash
 
-   $ cd PyFunceble && git checkout dev
-   $ git fetch origin && git merge origin/dev
-   $ python3 setup.py test
-   $ python3 setup.py install # Avoid this if you want to uninstall one day.
-   $ pip3 install --user --upgrade -e . # Prefer this method.
+   cd PyFunceble && git checkout dev
+   git fetch origin && git merge origin/dev
+   python3 setup.py test
+   python3 setup.py install # Avoid this if you want to uninstall one day.
+   pip3 install --user --upgrade -e . # Prefer this method.
 
 .. note::
    We recommend the :code:`--user` flag which installs the required dependencies
    at the user level. More information about it can be found on `pip documentation`_.
+
 .. warning::
    We do not recommend the :code:`--user` flag when using :code:`PyFunceble`
    into containers  or CI engines.

--- a/docs/update/index.rst
+++ b/docs/update/index.rst
@@ -1,5 +1,8 @@
 Update
 ======
 
+
 .. include:: stable.rst
 .. include:: dev.rst
+.. include:: version-4.x.rst
+.. include:: version-3.x.rst

--- a/docs/update/stable.rst
+++ b/docs/update/stable.rst
@@ -1,40 +1,6 @@
 Stable version
 --------------
 
-Important information for :code:`dev >= 3.2.11`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When you update from dev@<=3.2.10 or master@<=3.2.2 to newer release, there
-will be made a SQL conversion of the databases table layout.
-This can take up a sagnificent amount of time based on the size of the
-database.
-
-The table layout converion is being made to:
-
-1. Minimize the total size
-
-2. Optimize the sql flow and minimizing the read/write to save disk I/O.
-
-3. Minimize the number of SQL queries being made
-
-It have been seen taking days to convert these tables on very large
-installations.
-
-Important information for :code:`dev >= 4.0.0`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When you update to PyFunceble :code:`4.0.0`, there will be
-
-- a SQL conversion if you use the :code:`mysql` or `mariadb` database type.
-- a JSON to CSV conversion if one of those files is found in your filesystem:
-
-   - :code:`inactive_db.json`
-   - :code:`whois_db.json`
-
-- a breaking and compatibility issue if you try to directly (automatically ?)
-  read the data in the output directory. Indeed if you were looking for
-  :code:`output/domains/ACTIVE/list` in PyFunceble :code:`3.x`, in :code:`4.0`,
-  it is now under :code:`output/{{ input_file_name }}/domains/ACTIVE list`.
 
 Using :code:`pip`
 ^^^^^^^^^^^^^^^^^
@@ -42,9 +8,9 @@ Using :code:`pip`
 From PyPi
 """""""""
 
-::
+.. code-block:: bash
 
-   $ pip3 install --user --upgrade PyFunceble
+   pip3 install --user --upgrade PyFunceble
 
 .. note::
    We recommend the :code:`--user` flag which installs the required dependencies
@@ -58,9 +24,9 @@ From PyPi
 From GitHub
 """""""""""
 
-::
+.. code-block:: bash
 
-   $ pip3 install --user --upgrade git+https://github.com/funilrys/PyFunceble.git@master#egg=PyFunceble
+   pip3 install --user --upgrade git+https://github.com/funilrys/PyFunceble.git@master#egg=PyFunceble
 
 .. note::
    We recommend the :code:`--user` flag which installs the required dependencies
@@ -77,11 +43,11 @@ Using the AUR (for Arch Linux users)
 With makepkg
 """"""""""""
 
-::
+.. code-block:: bash
 
-    $ wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=python-pyfunceble
-    $ makepkg
-    $ sudo pacman -U python-pyfunceble*.tar.xz
+   wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=python-pyfunceble
+   makepkg
+   sudo pacman -U python-pyfunceble*.tar.xz
 
 With your favorite AUR helper
 """""""""""""""""""""""""""""
@@ -92,25 +58,25 @@ With your favorite AUR helper
    For more information about your current (or any other) AUR helper please
    report to `the ArchWiki page`_.
 
-::
+.. code-block:: bash
 
-   $ yourFavoriteAurHelper -Syu python-pyfunceble
+   yourFavoriteAurHelper -Syu python-pyfunceble
 
 Using docker (hub)
 ^^^^^^^^^^^^^^^^^^
 
 The image description can be found at https://hub.docker.com/r/pyfunceble/pyfunceble
 
-::
+.. code-block:: bash
 
-   $ docker pull pyfunceble/pyfunceble
+   docker pull pyfunceble/pyfunceble
 
 Using :code:`conda`
 ^^^^^^^^^^^^^^^^^^^
 
 Our repository is located at https://anaconda.org/pyfunceble/pyfunceble
 
-::
+.. code-block:: bash
 
    conda update -c conda-forge -c pyfunceble pyfunceble
 
@@ -120,13 +86,13 @@ Pure Python method
 
 Execute the following and enjoy PyFunceble!
 
-::
+.. code-block:: bash
 
-   $ cd PyFunceble
-   $ git checkout master && git fetch origin && git merge origin/master
-   $ python3 setup.py test
-   $ python3 setup.py install # Avoid this if you want to uninstall one day.
-   $ pip3 install --user --upgrade -e . # Prefer this method.
+   cd PyFunceble
+   git checkout master && git fetch origin && git merge origin/master
+   python3 setup.py test
+   python3 setup.py install # Avoid this if you want to uninstall one day.
+   pip3 install --user --upgrade -e . # Prefer this method.
 
 .. note::
    We recommend the :code:`--user` flag which installs the required dependencies

--- a/docs/update/stable.rst
+++ b/docs/update/stable.rst
@@ -71,15 +71,6 @@ The image description can be found at https://hub.docker.com/r/pyfunceble/pyfunc
 
    docker pull pyfunceble/pyfunceble
 
-Using :code:`conda`
-^^^^^^^^^^^^^^^^^^^
-
-Our repository is located at https://anaconda.org/pyfunceble/pyfunceble
-
-.. code-block:: bash
-
-   conda update -c conda-forge -c pyfunceble pyfunceble
-
 
 Pure Python method
 ^^^^^^^^^^^^^^^^^^

--- a/docs/update/version-3.x.rst
+++ b/docs/update/version-3.x.rst
@@ -1,5 +1,5 @@
 Important information for :code:`>= 3.2.11`
------------------------------------------------
+-------------------------------------------
 
 When you update from dev@<=3.2.10 or master@<=3.2.2 to newer release, there
 will be made a SQL conversion of the databases table layout.

--- a/docs/update/version-3.x.rst
+++ b/docs/update/version-3.x.rst
@@ -1,0 +1,18 @@
+Important information for :code:`>= 3.2.11`
+-----------------------------------------------
+
+When you update from dev@<=3.2.10 or master@<=3.2.2 to newer release, there
+will be made a SQL conversion of the databases table layout.
+This can take up a sagnificent amount of time based on the size of the
+database.
+
+The table layout converion is being made to:
+
+1. Minimize the total size
+
+2. Optimize the sql flow and minimizing the read/write to save disk I/O.
+
+3. Minimize the number of SQL queries being made
+
+It have been seen taking days to convert these tables on very large
+installations.

--- a/docs/update/version-4.x.rst
+++ b/docs/update/version-4.x.rst
@@ -1,0 +1,72 @@
+Important information for :code:`pyfunceble >= 4.0.0`
+-----------------------------------------------------
+
+When you upgrade PyFunceble from :code:`<4.x` to any version :code:`4.x`
+there will be:
+
+- a SQL conversion if you use the :code:`--database-type` :code:`mysql`
+  or :code:`mariadb`.
+- a JSON to CSV conversion if one of those files is found in your filesystem:
+
+   - :code:`inactive_db.json`
+   - :code:`whois_db.json`
+
+- The conversion of both SQL and json to CSV will take a "bit" of time as, it is
+  done in a single process mode, to avoid any hick-ups instead of loading the entire
+  file into memory. Loading the entire :code:`*.json` file into memory can have
+  severe consequences depending on the size of the source file.
+
+  .. note::
+
+      Once the job is done the :code:`json2csv` shouldn't appear again for this or later
+      :code:`4.x` releases.
+
+- A workaround for waiting on the rather slow :code:`json2csv`, you can delete
+
+   - :code:`inactive_db.json`
+   - :code:`whois_db.json` (Very Very Very bad idea in the long run...)
+  
+  However you will probably not benefit for by deleting the :code:`whois_db.json`
+  as this is the definitive slowest lookup process in the test flow, do to the
+  limitation in available API call you can do to :code:`WHOIS` servers before
+  getting banned. Therefore we **CAN NOT** recommend deleting this file, rather
+  than waiting for the conversion to finish.
+  
+- The output directory structure have been altered to work with the ability to
+  test more than one source at the time.
+  Prior to version :code:`4.0.0.ax` the output hirachi looked like 
+  :code:`output/domains/ACTIVE/list`.
+  In Pyfunceble version :code:`>=4.x` this have been altered to include the source
+  name and append to the folder structure.
+  From this version it will therefor looks like 
+  :code:`output/{{ input_source_name }}/domains/ACTIVE list`.
+
+
+.. note::
+
+   As consequence of the time consuming conversion we will advise you
+   to run a simple pyfunceble command like:
+
+   .. code-block:: bash
+
+      pyfunceble -d mypdns.org
+
+
+How long time does it take
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A few numbers to help you schedule your upgrade process.
+
+We have tested the SQL conversion with the following specifications
+
+  - 2 Xeon CPU x86_64 (8 cores) 2 GHz
+  - 48 GB ram.
+  - 1 SSD Kingston KC-600
+  - Mariadb 10.5, default config
+  - Non dedicated
+
+The database contains
+  - Roughly :code:`265.000` records in the test tables
+  - Approximately :code:`1.000.000` records within the :code:`pyfunceble_whois` table.
+
+This process toke about 10 hours to complete.

--- a/docs/update/version-4.x.rst
+++ b/docs/update/version-4.x.rst
@@ -34,7 +34,7 @@ there will be:
   
 - The output directory structure have been altered to work with the ability to
   test more than one source at the time.
-  Prior to version :code:`4.0.0.ax` the output hirachi looked like 
+  Prior to version :code:`4.0.0.ax` the output hierarchy looked like 
   :code:`output/domains/ACTIVE/list`.
   In Pyfunceble version :code:`>=4.x` this have been altered to include the source
   name and append to the folder structure.

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,4 +1,4 @@
 alabaster<0.8,>=0.7
-sphinx
+sphinx>=3.4.3
 sphinx_rtd_theme
 Pygments>=2.0


### PR DESCRIPTION
Fixes spirillen/PyFunceble#30

Small Changes... became bigger rewrites

Have devided the docs/update/ into 4 files with 4 heading and reversed the listed order to

  - stable
  - dev
  - 4.x
  - 3.x

This way we follow the changelog cronology

# requirements.doc.txt
  - Set forced version on sphinx to meet lexer for high ligthing code-block.