### PR TITLE
Added comment to Status output ordered as input

### DIFF
--- a/docs/usage/from-a-terminal.rst
+++ b/docs/usage/from-a-terminal.rst
@@ -762,7 +762,6 @@ Multiple space separated statuses can be given.
     duckduckgo.com                                       ACTIVE      DNSLOOKUP
     google-analytics.com                                 INACTIVE    STDLOOKUP
 
-
 *Show only active and inactive*
 
 .. code-block:: console
@@ -785,6 +784,14 @@ Multiple space separated statuses can be given.
     Subject                                              Status      Source
     ---------------------------------------------------- ----------- ----------
     google-analytics.com                                 INACTIVE    STDLOOKUP
+
+.. note::
+    If you have provided more than one $DOMAIN_FILE as input source, then the
+    printed status will be in same order as your $DOMAIN_FILE was given in the
+    input.
+
+    For an example you can visit:
+    `github <https://github.com/funilrys/PyFunceble/issues/238>`_
 
 
 ------


### PR DESCRIPTION
This commit should leave a comment about the printed order of the status outputs after running PyFunceble in a terminal

Related to: https://github.com/funilrys/PyFunceble/issues/238

Closes https://github.com/spirillen/PyFunceble/issues/45

The graphical results looks like this

![image](https://user-images.githubusercontent.com/44526987/122058842-58c1bd80-cdec-11eb-9b74-5d2ee2fdf30d.png)


<details><summary>note to self (@spirillen)</summary>

Link to the draft setup of GitLab on mypdns.org for phabricator replacement

https://www.mypdns.org/spirillen/PyFunceble/-/commit/f5c3ea1786740002757ed75aac5cc4dc282b6850#note_72

</details>