### PR TITLE
Special Rules: godaddysites.com + weebly.com

### DIFF
--- a/PyFunceble/checker/availability/extra_rules.py
+++ b/PyFunceble/checker/availability/extra_rules.py
@@ -89,6 +89,7 @@ class ExtraRulesHandler:
             r"\.blogspot\.": [self.__handle_blogspot],
             r"\.canalblog\.com$": [(self.__switch_to_down_if, 404)],
             r"\.github\.io$": [(self.__switch_to_down_if, 404)],
+            r"\.godaddysites\.com$": [(self.__switch_to_down_if, 404)],
             r"\.hpg.com.br$": [(self.__switch_to_down_if, 404)],
             r"\.liveadvert\.com$": [(self.__switch_to_down_if, 404)],
             r"\.skyrock\.com$": [(self.__switch_to_down_if, 404)],

--- a/PyFunceble/checker/availability/extra_rules.py
+++ b/PyFunceble/checker/availability/extra_rules.py
@@ -97,7 +97,7 @@ class ExtraRulesHandler:
             r"\.wix\.com$": [(self.__switch_to_down_if, 404)],
             r"\.wordpress\.com$": [self.__handle_wordpress_dot_com],
             r"\.weebly\.com$": [
-                (self.__switch_to_down_if, 406)
+                (self.__switch_to_down_if, 404)
             ],
         }
 

--- a/PyFunceble/checker/availability/extra_rules.py
+++ b/PyFunceble/checker/availability/extra_rules.py
@@ -96,6 +96,9 @@ class ExtraRulesHandler:
             r"\.tumblr\.com$": [(self.__switch_to_down_if, 404)],
             r"\.wix\.com$": [(self.__switch_to_down_if, 404)],
             r"\.wordpress\.com$": [self.__handle_wordpress_dot_com],
+            r"\.weebly\.com$": [
+                (self.__switch_to_down_if, 406)
+            ],
         }
 
         if PyFunceble.facility.ConfigLoader.is_already_loaded():


### PR DESCRIPTION
Covers the HTTP response code for outdated sub-sites to `godaddysites.com`

Examples for profe:

```shell
curl -I 'http://portailorange9.godaddysites.com'
HTTP/1.1 404 Not Found
Content-Type: text/html;charset=utf-8
Content-Length: 26455
Vary: Accept-Encoding
Server: DPS/1.11.6
X-SiteId: 1000
Set-Cookie: dps_site_id=1000; path=/
Date: Mon, 05 Jul 2021 19:32:59 GMT
X-Cache: MISS from firewall.matrix.lan
X-Cache-Lookup: MISS from firewall.matrix.lan:3128
Via: 1.1 firewall.matrix.lan (squid/4.15)
Connection: keep-alive
```

```shell
curl -I 'https://portailorange9.godaddysites.com'
HTTP/2 404 
content-type: text/html;charset=utf-8
content-length: 26455
vary: Accept-Encoding
server: DPS/1.11.6
x-siteid: 1000
set-cookie: dps_site_id=1000; path=/; secure
date: Mon, 05 Jul 2021 19:38:21 GMT
```

Found these examples in my big [hosts-source](https://github.com/Import-External-Sources/hosts-sources) lookup collection

```shell
git grep 'godaddysites.com' | wc -l
2350
```

PS: it was all tricked by https://github.com/mitchellkrogza/phishing/pull/25/files
  - thanks @Zachinquarantine