### PR TITLE
Updated URL for Porn Records by My Privacy DNS

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -55,7 +55,7 @@ contribution(s) and or issue report which made or make `PyFunceble`_ a better to
 .. _@ScriptTiger: https://github.com/ScriptTiger
 .. _@sjhgvr: https://github.com/sjhgvr
 .. _@speedmann: https://github.com/speedmann
-.. _@spirillen: https://www.mypdns.org/p/Spirillen/
+.. _@spirillen: https://mypdns.org/spirillen
 .. _@Wally3K: https://github.com/WaLLy3K
 .. _@xxcriticxx: https://github.com/xxcriticxx
 .. _@ybreza: https://github.com/ybreza

--- a/docs/facts/they-use-d-it.rst
+++ b/docs/facts/they-use-d-it.rst
@@ -63,7 +63,7 @@ PyFunceble!
 .. _Phishing.Database : https://github.com/mitchellkrogza/Phishing.Database
 .. _polish-adblock-filters : https://github.com/MajkiIT/polish-ads-filter/blob/master/polish-adblock-filters/adblock.txt
 .. _polish-pihole-filters : https://github.com/MajkiIT/polish-ads-filter/blob/master/polish-pihole-filters/hostfile.txt
-.. _porn-records : https://www.mypdns.org/project/view/10/
+.. _porn-records : https://mypdns.org/my-privacy-dns/porn-records
 .. _pornhosts : https://github.com/Import-External-Sources/pornhosts
 .. _Steven Black ad-hoc list : https://github.com/StevenBlack/hosts/blob/master/data/StevenBlack/hosts
 .. _Stop.Google.Analytics.Ghost.Spam.HOWTO : https://github.com/mitchellkrogza/Stop.Google.Analytics.Ghost.Spam.HOWTO


### PR DESCRIPTION
As Github toke down the PyFunceble test repository https://github.com/mypdns/porn-records
From My Privacy DNS, I have taken the liberty to set up a clone of
https://mypdns.org/my-privacy-dns/porn-records at https://github.com/porn-records/Porn-Records

I will in time make this doing the record testing, but the scheduler will need some work to protect it 
from being taken down as well.

This made me take a look at the referral links as phabricator no longer is the primary source
tool for mypdns.org

Thanks to @spirillen and @funilrys for your great work on both repositories.