### PR TITLE
sqlalchemy | Add pre_ping.

### DIFF
--- a/PyFunceble/database/session.py
+++ b/PyFunceble/database/session.py
@@ -150,6 +150,7 @@ class DBSession:
                 autoflush=True,
                 autocommit=False,
                 expire_on_commit=False,
+                pre_ping=True,
             )
 
         return self
@@ -180,7 +181,11 @@ class DBSession:
         )
 
         return sqlalchemy.orm.sessionmaker(
-            bind=engine, autoflush=True, autocommit=False, expire_on_commit=False
+            bind=engine,
+            autoflush=True,
+            autocommit=False,
+            expire_on_commit=False,
+            pre_ping=True,
         )
 
     @execute_if_authorized(None)
@@ -195,7 +200,11 @@ class DBSession:
         )
 
         return sqlalchemy.orm.sessionmaker(
-            bind=engine, autoflush=True, autocommit=False, expire_on_commit=False
+            bind=engine,
+            autoflush=True,
+            autocommit=False,
+            expire_on_commit=False,
+            pre_ping=True,
         )
 
     def close(self) -> "DBSession":

--- a/PyFunceble/database/session.py
+++ b/PyFunceble/database/session.py
@@ -142,7 +142,9 @@ class DBSession:
 
         if PyFunceble.sessions.DB_ENGINE is None:
             PyFunceble.sessions.DB_ENGINE = sqlalchemy.create_engine(
-                self.credential.get_uri(), poolclass=sqlalchemy.pool.NullPool
+                self.credential.get_uri(),
+                poolclass=sqlalchemy.pool.NullPool,
+                pool_pre_ping=True,
             )
 
             PyFunceble.sessions.DB_FACTORY = sqlalchemy.orm.sessionmaker(
@@ -150,7 +152,6 @@ class DBSession:
                 autoflush=True,
                 autocommit=False,
                 expire_on_commit=False,
-                pre_ping=True,
             )
 
         return self
@@ -177,7 +178,9 @@ class DBSession:
         """
 
         engine = sqlalchemy.create_engine(
-            self.credential.get_uri(), poolclass=sqlalchemy.pool.NullPool
+            self.credential.get_uri(),
+            poolclass=sqlalchemy.pool.NullPool,
+            pool_pre_ping=True,
         )
 
         return sqlalchemy.orm.sessionmaker(
@@ -185,7 +188,6 @@ class DBSession:
             autoflush=True,
             autocommit=False,
             expire_on_commit=False,
-            pre_ping=True,
         )
 
     @execute_if_authorized(None)
@@ -195,16 +197,13 @@ class DBSession:
         Create and return a new session.
         """
 
-        engine = sqlalchemy.create_engine(
-            self.credential.get_uri(),
-        )
+        engine = sqlalchemy.create_engine(self.credential.get_uri(), pool_pre_ping=True)
 
         return sqlalchemy.orm.sessionmaker(
             bind=engine,
             autoflush=True,
             autocommit=False,
             expire_on_commit=False,
-            pre_ping=True,
         )
 
     def close(self) -> "DBSession":


### PR DESCRIPTION
Indeed, before this patch, we weren't retrying to reconnect properly. This patch fixes the issue by using the pre_ping function of sqlalchemy.

This patch fixes #346.

Contributors:
  * @spirillen