### PR TITLE
Updated 000webhostapp.com rules

### DIFF
--- a/PyFunceble/checker/availability/extras/rules.py
+++ b/PyFunceble/checker/availability/extras/rules.py
@@ -78,7 +78,7 @@ class ExtraRulesHandler(ExtraRuleHandlerBase):
     def __init__(self, status: Optional[AvailabilityCheckerStatus] = None) -> None:
         self.regex_active2inactive = {
             r"\.000webhostapp\.com": [
-                (self.switch_to_down_if_status_code, 410),
+                (self.switch_to_down_if_status_code, {410, 424}),
             ],
             r"\.24\.eu$": [(self.switch_to_down_if_status_code, 503)],
             r"\.altervista\.org$": [(self.switch_to_down_if_status_code, 403)],


### PR DESCRIPTION
While working with https://github.com/funilrys/PyFunceble/issues/358, https://github.com/funilrys/PyFunceble/issues/354 & https://github.com/mitchellkrogza/Phishing.Database/issues/840 

I found that the hosting company also uses the HTTP code 428 for disabled (Website is archived.) 

Example URI

```css
http://httpmwankaiwqkcom.000webhostapp.com/
http://https244577889078564546464534353date.000webhostapp.com/
ipsizov.000webhostapp.com
```