### PR TITLE
neocities.org

### DIFF
--- a/PyFunceble/checker/availability/extras/rules.py
+++ b/PyFunceble/checker/availability/extras/rules.py
@@ -95,6 +95,7 @@ class ExtraRulesHandler(ExtraRuleHandlerBase):
             r"\.imgur\.com$": [self.handle_imgur_dot_com],
             r"\.liveadvert\.com$": [(self.switch_to_down_if_status_code, 404)],
             r"\.myhuaweicloudz\.com$": [(self.switch_to_down_if_status_code, 403)],
+            r"\.neocities\.org$": [(self.switch_to_down_if_status_code, 404)],
             r"^scnv\.io$": [(self.switch_to_down_if_status_code, 404)],
             r"\.skyrock\.com$": [(self.switch_to_down_if_status_code, 404)],
             r"\.squarespace.com$": [


### PR DESCRIPTION
After going through the lists of `*.neocities.org` https://github.com/mypdns/matrix/issues/127271 from the @phishingdatabase project, I've found that they uses HTTP code 404 for subdomains that have been taken down. Hence this MR

Ass mentioned in https://github.com/neocities/neocities/issues/659